### PR TITLE
Feature/no-args-comma-dangle

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,0 +1,11 @@
+extends: "./index.js"
+
+plugins:
+- import
+
+env:
+  node: true
+  es6: true
+
+parserOptions:
+  sourceType: script

--- a/index.js
+++ b/index.js
@@ -14,6 +14,15 @@ module.exports = {
         ignoreTemplateLiterals: false,
       },
     ],
-    'no-void': 'off'
+    'no-void': 'off',
+    'comma-dangle': [
+      'error', {
+        arrays: 'always-multiline',
+        objects: 'always-multiline',
+        imports: 'always-multiline',
+        exports: 'always-multiline',
+        functions: 'never',
+      },
+    ],
   },
 };

--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   extends: 'airbnb-base',
   rules: {

--- a/release-notes.yml
+++ b/release-notes.yml
@@ -3,7 +3,7 @@ title: Release Notes of Release Notes ESlint config
 releases:
 - version: Next
   improved:
-  - Definition of comma dangle rules. Functions params must not use trailing commas.
+  - Definition of comma dangle rules. Function params must not use trailing commas, anymore.
 - version: 0.1.0
   date: 2017-07-08T20:51:00Z
   title: First Release

--- a/release-notes.yml
+++ b/release-notes.yml
@@ -1,6 +1,9 @@
 title: Release Notes of Release Notes ESlint config
 
 releases:
+- version: Next
+  improved:
+  - Definition of comma dangle rules. Functions params must not use trailing commas.
 - version: 0.1.0
   date: 2017-07-08T20:51:00Z
   title: First Release


### PR DESCRIPTION
currently the following code produces an eslint error:
_**error**  Missing trailing comma  - comma-dangle_
```
function foo(
  a,
  b
) {
 // do something
}
```